### PR TITLE
Changed the row provider to expose visibility via IsOffscreen property

### DIFF
--- a/spec/screens/main_screen.rb
+++ b/spec/screens/main_screen.rb
@@ -8,6 +8,7 @@ class MainScreen
   button(:invokable_control, id: 'pictureBox1')
   button(:add_rows, :value => 'Add Row')
   button(:update_headers, :value => 'Update Headers')
+  button(:toggle_row, :value => 'Toggle Row')
 
   label(:status, id: 'StatusBar.Pane0')
 

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -17,7 +17,7 @@ describe 'table' do
     When do
 		screen.add_grid_items 3 
 		screen.toggle_row
-	end
+    end
     Then { screen.the_grid.rows.map(&:visible?) == [false, true, true] }
   end
   
@@ -26,7 +26,7 @@ describe 'table' do
 		screen.add_grid_items 3 
 		screen.toggle_row
 		screen.toggle_row
-	end
+    end
     Then { screen.the_grid.rows.map(&:visible?) == [true, true, true] }
   end
 

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -12,6 +12,23 @@ describe 'table' do
     When { screen.add_grid_items 10 }
     Then { screen.the_grid.count == 10 }
   end
+  
+  context('table hides rows') do
+    When do
+		screen.add_grid_items 3 
+		screen.toggle_row
+	end
+    Then { screen.the_grid.rows.map(&:visible?) == [false, true, true] }
+  end
+  
+  context('table shows rows') do
+    When do
+		screen.add_grid_items 3 
+		screen.toggle_row
+		screen.toggle_row
+	end
+    Then { screen.the_grid.rows.map(&:visible?) == [true, true, true] }
+  end
 
   context 'headers' do
     Given(:headers) { grid.filter(control_type: :header_item) }

--- a/src/UIA.Extensions.TestApplication/MainForm.Designer.cs
+++ b/src/UIA.Extensions.TestApplication/MainForm.Designer.cs
@@ -39,6 +39,7 @@
             this.monthCalendar = new System.Windows.Forms.MonthCalendar();
             this.statusStrip1 = new System.Windows.Forms.StatusStrip();
             this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
+            this.toggleRowButton = new System.Windows.Forms.Button();
             this.basicPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDown)).BeginInit();
@@ -51,6 +52,7 @@
             this.basicPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.basicPanel.Controls.Add(this.toggleRowButton);
             this.basicPanel.Controls.Add(this.pictureBox1);
             this.basicPanel.Controls.Add(this.updateHeaders);
             this.basicPanel.Controls.Add(this.deleteButton);
@@ -160,6 +162,16 @@
             this.toolStripStatusLabel1.Size = new System.Drawing.Size(118, 17);
             this.toolStripStatusLabel1.Text = "toolStripStatusLabel1";
             // 
+            // toggleRowButton
+            // 
+            this.toggleRowButton.Location = new System.Drawing.Point(269, 207);
+            this.toggleRowButton.Name = "toggleRowButton";
+            this.toggleRowButton.Size = new System.Drawing.Size(75, 23);
+            this.toggleRowButton.TabIndex = 8;
+            this.toggleRowButton.Text = "Toggle Row";
+            this.toggleRowButton.UseVisualStyleBackColor = true;
+            this.toggleRowButton.Click += new System.EventHandler(this.toggleRowButton_Click);
+            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -194,6 +206,7 @@
         private System.Windows.Forms.StatusStrip statusStrip1;
         private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel1;
         private System.Windows.Forms.PictureBox pictureBox1;
+        private System.Windows.Forms.Button toggleRowButton;
     }
 }
 

--- a/src/UIA.Extensions.TestApplication/MainForm.cs
+++ b/src/UIA.Extensions.TestApplication/MainForm.cs
@@ -64,5 +64,15 @@ namespace UIA.Extensions.TestApplication
                 column.HeaderText += " Updated";
             }
         }
+
+        private void toggleRowButton_Click(object sender, EventArgs e)
+        {
+            if (dataGridView.RowCount > 0)
+            {
+                _bindingSource.SuspendBinding();
+                dataGridView.Rows[0].Visible = !dataGridView.Rows[0].Visible;
+                _bindingSource.ResumeBinding();
+            }
+        }
     }
 }

--- a/src/UIA.Extensions.Units/AutomationProviders/Tables/Stubs/RowInformationStub.cs
+++ b/src/UIA.Extensions.Units/AutomationProviders/Tables/Stubs/RowInformationStub.cs
@@ -8,23 +8,21 @@ namespace UIA.Extensions.AutomationProviders.Tables.Stubs
     {
         private bool _wasSelected;
         private bool _wasCleared;
+        private bool _wasHidden;
         private readonly string _value;
         private readonly List<CellInformation> _cells;
 
         public RowInformationStub()
             : this("Default")
         { }
-
         public RowInformationStub(int which)
             : this("Row" + which)
         { }
-
         public RowInformationStub(string what)
         {
             _cells = new List<CellInformation>();
             _value = what;
         }
-
         public RowInformationStub(List<CellInformation> cells)
         {
             _cells = cells;
@@ -58,6 +56,12 @@ namespace UIA.Extensions.AutomationProviders.Tables.Stubs
         public override bool IsSelected
         {
             get { return _wasSelected; }
+        }
+
+        public override bool IsVisible
+        {
+            get { return !_wasHidden; }
+            set { _wasHidden = !value; }
         }
 
         public void ShouldHaveBeenSelected()

--- a/src/UIA.Extensions/AutomationProviders/Defaults/Tables/DataGridRowInformation.cs
+++ b/src/UIA.Extensions/AutomationProviders/Defaults/Tables/DataGridRowInformation.cs
@@ -50,5 +50,11 @@ namespace UIA.Extensions.AutomationProviders.Defaults.Tables
         {
             get { return DataGridViewRow.Selected; }
         }
+
+        public override bool IsVisible
+        {
+            get { return DataGridViewRow.Visible; }
+            set { DataGridViewRow.Visible = value; }
+        }
     }
 }

--- a/src/UIA.Extensions/AutomationProviders/Interfaces/Tables/RowInformation.cs
+++ b/src/UIA.Extensions/AutomationProviders/Interfaces/Tables/RowInformation.cs
@@ -12,6 +12,7 @@ namespace UIA.Extensions.AutomationProviders.Interfaces.Tables
         public abstract void AddToSelection();
         public abstract void ClearSelection();
         public abstract bool IsSelected { get; }
+        public abstract bool IsVisible { get; set; }
 
         public override bool Equals(object obj)
         {

--- a/src/UIA.Extensions/AutomationProviders/Tables/TableRowProvider.cs
+++ b/src/UIA.Extensions/AutomationProviders/Tables/TableRowProvider.cs
@@ -9,13 +9,16 @@ namespace UIA.Extensions.AutomationProviders.Tables
     {
         private readonly RowInformation _rowInformation;
 
-        public TableRowProvider(AutomationProvider parent, RowInformation rowInformation) : base(parent, SelectionItemPattern.Pattern)
+        public TableRowProvider(AutomationProvider parent, RowInformation rowInformation)
+            : base(parent, SelectionItemPattern.Pattern)
         {
             _rowInformation = rowInformation;
             Name = rowInformation.Value;
             ControlType = ControlType.DataItem;
 
             rowInformation.Cells.ForEach(x => AddChild(new TableCellProvider(this, x)));
+
+            SetPropertyValue(AutomationElementIdentifiers.IsOffscreenProperty.Id, () => !rowInformation.IsVisible);
         }
 
         public override string Name


### PR DESCRIPTION
We made a change to how we filter the rows on a datagrid, which instead of rebinding with a new datasource that doesn't contain the invalid rows, we merely set them to .Visible = False. This broke a couple of our cuke tests since the providers make no distinction between visible and invisible rows.

First you can see the row as usual
![image](https://cloud.githubusercontent.com/assets/2745528/8597428/55465a52-2623-11e5-8213-c8128548203a.png)
But when we filter it out, the provider still thinks it's there
![image](https://cloud.githubusercontent.com/assets/2745528/8597455/76245fbc-2623-11e5-8762-5e88656fd478.png)

The changes here use the `IsVisible` property of the datagrid row to set the `IsOffscreen` property of the row provider. This should allow the normal `visible?` property in ruby to return the correct value.