### PR TITLE
Bump rake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@ source 'http://rubygems.org'
 
 gem 'rake'
 gem 'rspec-given'
-gem 'albacore', '2.0.16'
+gem 'albacore', :git => 'https://github.com/Albacore/albacore.git'
 gem 'mohawk', '0.4.2'
 gem 'childprocess'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,19 @@
+GIT
+  remote: https://github.com/Albacore/albacore.git
+  revision: af29f9ba4e0c858cd113757f414f212c099171e3
+  specs:
+    albacore (3.0.1)
+      map (~> 6.5)
+      nokogiri (~> 1.5)
+      rake (~> 12)
+      semver2 (~> 3.4)
+
 GEM
   remote: http://rubygems.org/
   specs:
-    albacore (2.0.16)
-      map (~> 6.5)
-      nokogiri (~> 1.5)
-      rake (~> 10)
-      semver2 (~> 3.4)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     data_magic (1.2)
       faker (>= 1.1.2)
       yml_reader (>= 0.6)
@@ -31,7 +36,7 @@ GEM
       mini_portile2 (~> 2.4.0)
     page_navigation (0.10)
       data_magic (>= 0.22)
-    rake (10.5.0)
+    rake (12.3.3)
     require_all (3.0.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -60,7 +65,7 @@ PLATFORMS
   x86-mingw32
 
 DEPENDENCIES
-  albacore (= 2.0.16)
+  albacore!
   childprocess
   mohawk (= 0.4.2)
   rake


### PR DESCRIPTION
We are already referencing the latest version of `albacore` (3.0.1) that is on RubyGems and it is locking `rake` at 10, however they have a merged PR that bumps it to 12, which is what we need (https://github.com/Albacore/albacore/pull/251). The issue we're running into is the `albacore` maintainers haven't cut a new gem for it, so I'm referencing the github repo instead. That allows us to get an updated version of `rake` in here, which will fix the security alert
CVE-2020-8130
