### PR TITLE
Target .Net 4.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ Generated_Code #added for RIA/Silverlight projects
 _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
+.vs/

--- a/spec/screens/main_screen.rb
+++ b/spec/screens/main_screen.rb
@@ -10,7 +10,7 @@ class MainScreen
   button(:update_headers, :value => 'Update Headers')
   button(:toggle_row, :value => 'Toggle Row')
 
-  label(:status, id: 'StatusBar.Pane0')
+  label(:status_strip, id: 'statusStrip1')
 
   table(:the_grid, :id => 'dataGridView')
 
@@ -23,5 +23,9 @@ class MainScreen
   def add_grid_items(how_many)
     self.how_many = how_many.to_s
     add_rows
+  end
+
+  def status
+    self.status_strip_view.children[0].name
   end
 end

--- a/src/UIA.Extensions.TestApplication/MainForm.resx
+++ b/src/UIA.Extensions.TestApplication/MainForm.resx
@@ -112,12 +112,12 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
 </root>

--- a/src/UIA.Extensions.TestApplication/Properties/Resources.Designer.cs
+++ b/src/UIA.Extensions.TestApplication/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace UIA.Extensions.TestApplication.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/src/UIA.Extensions.TestApplication/Properties/Settings.Designer.cs
+++ b/src/UIA.Extensions.TestApplication/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace UIA.Extensions.TestApplication.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.6.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.4.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/src/UIA.Extensions.TestApplication/UIA.Extensions.TestApplication.csproj
+++ b/src/UIA.Extensions.TestApplication/UIA.Extensions.TestApplication.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>UIA.Extensions.TestApplication</RootNamespace>
     <AssemblyName>UIA.Extensions.TestApplication</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/src/UIA.Extensions.TestApplication/UIA.Extensions.TestApplication.csproj
+++ b/src/UIA.Extensions.TestApplication/UIA.Extensions.TestApplication.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>UIA.Extensions.TestApplication</RootNamespace>
     <AssemblyName>UIA.Extensions.TestApplication</AssemblyName>
-    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/src/UIA.Extensions.TestApplication/app.config
+++ b/src/UIA.Extensions.TestApplication/app.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/>
   </startup>
 </configuration>

--- a/src/UIA.Extensions.TestApplication/app.config
+++ b/src/UIA.Extensions.TestApplication/app.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
   </startup>
 </configuration>

--- a/src/UIA.Extensions.Units/AutomationProviders/AutomationProviderTest.cs
+++ b/src/UIA.Extensions.Units/AutomationProviders/AutomationProviderTest.cs
@@ -71,7 +71,7 @@ namespace UIA.Extensions.AutomationProviders
         public void ItIsConsideredAServerSideProvider()
         {
             (_automationProvider.ProviderOptions & ProviderOptions.ServerSideProvider)
-                .Should().BeEquivalentTo(ProviderOptions.ServerSideProvider);
+                .Should().HaveFlag(ProviderOptions.ServerSideProvider);
         }
 
         [Test]

--- a/src/UIA.Extensions.Units/UIA.Extensions.Units.csproj
+++ b/src/UIA.Extensions.Units/UIA.Extensions.Units.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>UIA.Extensions</RootNamespace>
     <AssemblyName>UIA.Extensions.Units</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -97,22 +97,22 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Castle.Core">
-      <Version>4.4.1</Version>
+      <Version>5.1.0</Version>
     </PackageReference>
     <PackageReference Include="FluentAssertions">
-      <Version>5.10.3</Version>
+      <Version>6.8.0</Version>
     </PackageReference>
     <PackageReference Include="Moq">
-      <Version>4.14.5</Version>
+      <Version>4.18.2</Version>
     </PackageReference>
     <PackageReference Include="NUnit">
-      <Version>3.12.0</Version>
+      <Version>3.13.3</Version>
     </PackageReference>
     <PackageReference Include="Should">
       <Version>1.1.20</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
-      <Version>4.7.1</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="System.Threading.Tasks.Extensions">
       <Version>4.5.4</Version>

--- a/src/UIA.Extensions.Units/UIA.Extensions.Units.csproj
+++ b/src/UIA.Extensions.Units/UIA.Extensions.Units.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>UIA.Extensions</RootNamespace>
     <AssemblyName>UIA.Extensions.Units</AssemblyName>
-    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/src/UIA.Extensions.Units/app.config
+++ b/src/UIA.Extensions.Units/app.config
@@ -1,15 +1,18 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
+    <runtime>
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <dependentAssembly>
+                <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+            </dependentAssembly>
+        </assemblyBinding>
+    </runtime>
+    <startup>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1" />
+    </startup>
 </configuration>

--- a/src/UIA.Extensions.Units/app.config
+++ b/src/UIA.Extensions.Units/app.config
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <runtime>
-        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-            <dependentAssembly>
-                <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
-            </dependentAssembly>
-            <dependentAssembly>
-                <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-            </dependentAssembly>
-        </assemblyBinding>
-    </runtime>
-    <startup>
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1" />
-    </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
+  </startup>
 </configuration>

--- a/src/UIA.Extensions/UIA.Extensions.csproj
+++ b/src/UIA.Extensions/UIA.Extensions.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>UIA.Extensions</RootNamespace>
     <AssemblyName>UIA.Extensions</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/UIA.Extensions/UIA.Extensions.csproj
+++ b/src/UIA.Extensions/UIA.Extensions.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>UIA.Extensions</RootNamespace>
     <AssemblyName>UIA.Extensions</AssemblyName>
-    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/build.cake
+++ b/src/build.cake
@@ -18,7 +18,7 @@
 var testAssemblyPattern = "*.Units";
 var integrationTestAssemblyPattern = "*.Tests.Integration";
 
-var msBuildToolVersion = MSBuildToolVersion.VS2019;
+var msBuildToolVersion = MSBuildToolVersion.VS2022;
 
 var target         = Argument("target", "Default");
 var configuration  = Argument("configuration", "Release");

--- a/src/tools/packages.config
+++ b/src/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.38.4" />
+    <package id="Cake" version="1.3.0" />
 </packages>


### PR DESCRIPTION
* Target .Net 4.8
* Use VS2022 for build
* Update nuget dependencies
* Changed how we access the label on a status strip. Using the first child name seems to give us the right text. Only seemed to be an issue on Win11